### PR TITLE
feat: add dependency CVE triage prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ Explore the available prompts and their intended use cases:
 | [check-access-controls.prompt.md](prompts/check-access-controls.prompt.md) | Audit authorization and access control weaknesses. | Ensure RBAC/ABAC enforcement and consistent permission checks. |
 | [check-for-secrets.prompt.md](prompts/check-for-secrets.prompt.md) | Detect hardcoded secrets and credentials. | Locate embedded keys or tokens and suggest secure storage. |
 | [check-for-unvalidated-genai-acceptances.prompt.md](prompts/check-for-unvalidated-genai-acceptances.prompt.md) | Find unvalidated AI-generated code or hallucinated assets. | Verify that AI suggestions are real, tested, and documented. |
+| [dependency-cve-triage.prompt.md](prompts/dependency-cve-triage.prompt.md) | Triage a known CVE against a project's dependency: explain the exploit, assess reachability and configuration, and produce a structured Dependency Tracker report. | Analyze a specific CVE's impact on local code, determine exploitability, and generate a concise triage report. |
 | [review-auth-flows.prompt.md](prompts/review-auth-flows.prompt.md) | Evaluate authentication logic and session handling. | Review login flows for common risks and best practices. |
 | [scan-for-insecure-apis.prompt.md](prompts/scan-for-insecure-apis.prompt.md) | Spot deprecated or insecure API usage. | Replace risky APIs with modern, safer alternatives. |
 | [secure-code-review.prompt.md](prompts/secure-code-review.prompt.md) | Perform a comprehensive security review of the codebase. | Conduct an end-to-end audit for security issues. |
 | [validate-input-handling.prompt.md](prompts/validate-input-handling.prompt.md) | Check for missing or unsafe input validation. | Evaluate request handling for validation and sanitization gaps. |
+
 
 ---
 

--- a/prompts/dependency-cve-triage.prompt.md
+++ b/prompts/dependency-cve-triage.prompt.md
@@ -1,0 +1,36 @@
+# 🛡️ Prompt: Dependency CVE Triage
+
+Act as a **security vulnerability analyst** investigating a known CVE in the context of a web application dependency.
+
+---
+
+## 🧭 Instructions
+
+1. **Check CVE context**  
+   If `{{CVE_NUMBER}}` is not provided or not found in the surrounding code or comments, ask:  
+   > _"Which CVE would you like me to analyze?"_  
+   Wait for a response before continuing.
+
+2. **CVE Lookup & Explanation**  
+   - Retrieve details about `{{CVE_NUMBER}}`  
+   - Summarize how the exploit works, including vector and preconditions
+
+3. **Risk Assessment in Local Context**  
+   - Evaluate whether the affected dependency is used in a vulnerable way  
+   - Consider: reachability, configuration, environmental constraints, and runtime protections
+
+4. **Prepare Structured Report**  
+   Output the following fields for integration with Dependency Tracker:
+
+   ```txt
+   - **Comment:** TEXT_FIELD
+   - **Analysis:** [Not Set, Exploitable, In Triage, Resolved, False Positive, Not Affected]
+   - **Justification:** [Not Set, Code not present, Code not reachable, Requires configuration, Requires dependency, Requires environment, Protected by compiler, Protected at runtime, Protected at perimeter, Protected by mitigating control]
+   - **Vendor Response:** [Not Set, Can not fix, Will not fix, Update, Rollback, Workaround available]
+   - **Details:** TEXT_FIELD
+   ```
+
+---
+
+Use clear and concise reasoning. If implementation context is missing, ask for what you need to make a grounded assessment.
+Avoid speculation. If you cannot determine the impact, state that explicitly.


### PR DESCRIPTION
- Add dependency CVE triage prompt for security vulnerability analysis.
- Update `README.md` to include the new prompt in the prompt catalogue table.